### PR TITLE
Create tutor-leaderboard command

### DIFF
--- a/src/commands/tutor-commands/tutor-leaderboard.ts
+++ b/src/commands/tutor-commands/tutor-leaderboard.ts
@@ -32,7 +32,7 @@ export const tutorleaderboard: Command = {
       },
     ]);
 
-    const errorTitle = "❌ Leaderboard Canceled!";
+    const errorTitle = "❌ Tutor Leaderboard Canceled!";
 
     const maxSlots = (number?.value || 10) as number;
     const leaderboardResponse = await getTutorLeaderboard(maxSlots);

--- a/src/commands/tutor-commands/tutor-leaderboard.ts
+++ b/src/commands/tutor-commands/tutor-leaderboard.ts
@@ -12,8 +12,8 @@ const tutorleaderboardBody = (array: string[]): string => {
 
 export const tutorleaderboard: Command = {
   data: new SlashCommandBuilder()
-    .setName("leaderboard")
-    .setDescription("See the CougarCoin leaderboard!")
+    .setName("tutor-leaderboard")
+    .setDescription("See the top tutor!")
     .addNumberOption((option) =>
       option
         .setName("number")

--- a/src/commands/tutor-commands/tutor-leaderboard.ts
+++ b/src/commands/tutor-commands/tutor-leaderboard.ts
@@ -1,0 +1,54 @@
+import { SlashCommandBuilder } from "discord.js";
+import { Command } from "../../interfaces/Command";
+import { createEmbed } from "../../utils/embeded";
+import { getTutorLeaderboard } from "../../utils/supabase";
+import { commandLog, sendError } from "../../utils/logs";
+
+const tutorleaderboardBody = (array: string[]): string => {
+  let body = "";
+  array.forEach((slot) => (body = `${body}${slot}\n`));
+  return body;
+};
+
+export const tutorleaderboard: Command = {
+  data: new SlashCommandBuilder()
+    .setName("leaderboard")
+    .setDescription("See the CougarCoin leaderboard!")
+    .addNumberOption((option) =>
+      option
+        .setName("number")
+        .setDescription("Number of leaderboard spaces you want to see!")
+        .setMaxValue(20)
+        .setMinValue(1)
+        .setRequired(false)
+    ),
+  run: async (interaction) => {
+    await interaction.deferReply({ ephemeral: false });
+    const number = interaction.options.get("number", false);
+    commandLog(interaction, "/leaderboard", "Green", [
+      {
+        name: "number",
+        value: `${number}`,
+      },
+    ]);
+
+    const errorTitle = "❌ Leaderboard Canceled!";
+
+    const maxSlots = (number?.value || 10) as number;
+    const leaderboardResponse = await getTutorLeaderboard(maxSlots);
+
+    if (leaderboardResponse.error) {
+      await sendError(errorTitle, leaderboardResponse.message, interaction);
+      return;
+    }
+
+    const leaderboardString = tutorleaderboardBody(leaderboardResponse.data);
+
+    const returnMessage = createEmbed(
+      "<a:CC:991512220909445150> CougarCoin Leaderboard!",
+      leaderboardString || "The leaderboard is empty!"
+    ).setColor("Green");
+    await interaction.editReply({ embeds: [returnMessage] });
+    return;
+  },
+};

--- a/src/commands/tutor-commands/tutor-leaderboard.ts
+++ b/src/commands/tutor-commands/tutor-leaderboard.ts
@@ -45,7 +45,7 @@ export const tutorleaderboard: Command = {
     const leaderboardString = tutorleaderboardBody(leaderboardResponse.data);
 
     const returnMessage = createEmbed(
-      "<a:CC:991512220909445150> CougarCoin Leaderboard!",
+      "Tutor Leaderboard!",
       leaderboardString || "The leaderboard is empty!"
     ).setColor("Green");
     await interaction.editReply({ embeds: [returnMessage] });

--- a/src/commands/tutor-commands/tutor-leaderboard.ts
+++ b/src/commands/tutor-commands/tutor-leaderboard.ts
@@ -25,7 +25,7 @@ export const tutorleaderboard: Command = {
   run: async (interaction) => {
     await interaction.deferReply({ ephemeral: false });
     const number = interaction.options.get("number", false);
-    commandLog(interaction, "/leaderboard", "Green", [
+    commandLog(interaction, "/tutor-leaderboard", "Green", [
       {
         name: "number",
         value: `${number}`,

--- a/src/commands/tutor-commands/tutor-leaderboard.ts
+++ b/src/commands/tutor-commands/tutor-leaderboard.ts
@@ -4,8 +4,8 @@ import { createEmbed } from "../../utils/embeded";
 import { getTutorLeaderboard } from "../../utils/supabase";
 import { commandLog, sendError } from "../../utils/logs";
 
-const tutorleaderboardBody = (bodyContent: string[]): string => {
-  return bodyContent.join('\n');
+const buildEmbedBody = (bodyArray: string[]): string => {
+  return bodyArray.join('\n');
 };
 
 export const tutorleaderboard: Command = {
@@ -40,7 +40,7 @@ export const tutorleaderboard: Command = {
       return;
     }
 
-    const leaderboardString = tutorleaderboardBody(leaderboardResponse.data);
+    const leaderboardString = buildEmbedBody(leaderboardResponse.data);
 
     const returnMessage = createEmbed(
       "<:tutor:1151206705913417828> Tutor Leaderboard!",

--- a/src/commands/tutor-commands/tutor-leaderboard.ts
+++ b/src/commands/tutor-commands/tutor-leaderboard.ts
@@ -45,7 +45,7 @@ export const tutorleaderboard: Command = {
     const leaderboardString = tutorleaderboardBody(leaderboardResponse.data);
 
     const returnMessage = createEmbed(
-      "Tutor Leaderboard!",
+      "<:tutor:1151206705913417828> Tutor Leaderboard!",
       leaderboardString || "The leaderboard is empty!"
     ).setColor("Green");
     await interaction.editReply({ embeds: [returnMessage] });

--- a/src/commands/tutor-commands/tutor-leaderboard.ts
+++ b/src/commands/tutor-commands/tutor-leaderboard.ts
@@ -4,10 +4,8 @@ import { createEmbed } from "../../utils/embeded";
 import { getTutorLeaderboard } from "../../utils/supabase";
 import { commandLog, sendError } from "../../utils/logs";
 
-const tutorleaderboardBody = (array: string[]): string => {
-  let body = "";
-  array.forEach((slot) => (body = `${body}${slot}\n`));
-  return body;
+const tutorleaderboardBody = (bodyContent: string[]): string => {
+  return bodyContent.join('\n');
 };
 
 export const tutorleaderboard: Command = {

--- a/src/utils/_Commandlists.ts
+++ b/src/utils/_Commandlists.ts
@@ -24,6 +24,7 @@ import { tutorlog } from "../commands/tutor-commands/tutor-log";
 import { appointTutor } from "../commands/officer-commands/appoint-tutor";
 import { updateProfile } from "../commands/user-commands/update-profile";
 import { createProfile } from "../commands/user-commands/create-profile";
+import { tutorleaderboard } from "../commands/tutor-commands/tutor-leaderboard";
 
 export const CommandList: Command[] = [
   attendance,
@@ -51,4 +52,5 @@ export const CommandList: Command[] = [
   appointTutor,
   updateProfile,
   createProfile,
+  tutorleaderboard,
 ];

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -388,6 +388,12 @@ export interface Database {
           contact_id: string
         }
         Returns: number
+      },
+      hour: {
+        Args: {
+          tutor_id: string
+        }
+        Returns: number
       }
     }
     Enums: {

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1142,7 +1142,6 @@ export const getTutorLeaderboard = async (
 
   tutorUniqueBalancePairs.sort((a, b) => b.tutorBalance - a.tutorBalance);
   const arrayString: string[] = [];
-  let counter = 0;
 
   for (let i = 0; i < tutorUniqueBalancePairs.length; i++) {
     const { tutor_id, tutorBalance } = tutorUniqueBalancePairs[i];
@@ -1154,6 +1153,10 @@ export const getTutorLeaderboard = async (
     const UUID = tutorIdentifierResponse.data.contact_id;
     const identifierResponse = await getContact({ contact_id: UUID });
 
+    if (identifierResponse.error) {
+      return identifierResponse;
+    }
+
     const { discord_snowflake, first_name, last_name } = identifierResponse.data;
     const identifier = discord_snowflake
       ? `<@${discord_snowflake}>`
@@ -1161,9 +1164,8 @@ export const getTutorLeaderboard = async (
     const slot = `${i + 1}. ${identifier}: **${tutorBalance}**`;
 
     arrayString.push(slot);
-    counter++;
 
-    if (counter == maxSlots) break;
+    if (arrayString.length === maxSlots) break;
   }
 
   return {

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1166,7 +1166,7 @@ export const getTutorLeaderboard = async (
     else if (i === 2){ icon = "🥉";} 
     else { icon = `${i + 1}.`; }
 
-    const slot = `${icon} ${identifier}: **${tutorBalance}**`;
+    const slot = `${icon} ${identifier}: **${tutorBalance}** hour(s)`;
 
     arrayString.push(slot);
 

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1158,10 +1158,15 @@ export const getTutorLeaderboard = async (
     }
 
     const { discord_snowflake, first_name, last_name } = identifierResponse.data;
-    const identifier = discord_snowflake
-? `<@${discord_snowflake}>`
-      : `${first_name} ${last_name}`;
-    const slot = `${i + 1}. ${identifier}: **${tutorBalance}**`;
+    const identifier = discord_snowflake ? `<@${discord_snowflake}>` : `${first_name} ${last_name}`;
+    let icon = "";
+
+    if (i === 0) { icon = "🥇"; } 
+    else if (i === 1){ icon = "🥈"; }
+    else if (i === 2){ icon = "🥉";} 
+    else { icon = `${i + 1}.`; }
+
+    const slot = `${icon} ${identifier}: **${tutorBalance}**`;
 
     arrayString.push(slot);
 

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1161,9 +1161,9 @@ export const getTutorLeaderboard = async (
     const identifier = discord_snowflake ? `<@${discord_snowflake}>` : `${first_name} ${last_name}`;
     let icon = "";
 
-    if (i === 0) { icon = "🥇"; } 
-    else if (i === 1){ icon = "🥈"; }
-    else if (i === 2){ icon = "🥉";} 
+    if (arrayString.length === 0) { icon = "🥇"; } 
+    else if (arrayString.length === 1){ icon = "🥈"; }
+    else if (arrayString.length === 2){ icon = "🥉";} 
     else { icon = `${i + 1}.`; }
 
     const slot = `${icon} ${identifier}: **${tutorBalance}** hour(s)`;

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1164,7 +1164,7 @@ export const getTutorLeaderboard = async (
     if (arrayString.length === 0) { icon = "🥇"; } 
     else if (arrayString.length === 1){ icon = "🥈"; }
     else if (arrayString.length === 2){ icon = "🥉";} 
-    else { icon = `${i + 1}.`; }
+    else { icon = `${arrayString.length + 1}.`; }
 
     const slot = `${icon} ${identifier}: **${tutorBalance}** hour(s)`;
 

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1142,8 +1142,9 @@ export const getTutorLeaderboard = async (
 
   tutorUniqueBalancePairs.sort((a, b) => b.tutorBalance - a.tutorBalance);
   const arrayString: string[] = [];
+  let counter = 0;
 
-  for (let i = 0; i < tutorUniqueBalancePairs.length && i < maxSlots; i++) {
+  for (let i = 0; i < tutorUniqueBalancePairs.length; i++) {
     const { tutor_id, tutorBalance } = tutorUniqueBalancePairs[i];
     const tutorIdentifierResponse = await getTutor({ tutor_id });
     
@@ -1151,7 +1152,7 @@ export const getTutorLeaderboard = async (
       continue;
     }
     const UUID = tutorIdentifierResponse.data.contact_id;
-    const identifierResponse = await getContact({ contact_id: UUID })
+    const identifierResponse = await getContact({ contact_id: UUID });
 
     const { discord_snowflake, first_name, last_name } = identifierResponse.data;
     const identifier = discord_snowflake
@@ -1160,6 +1161,9 @@ export const getTutorLeaderboard = async (
     const slot = `${i + 1}. ${identifier}: **${tutorBalance}**`;
 
     arrayString.push(slot);
+    counter++;
+
+    if (counter == maxSlots) break;
   }
 
   return {

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1078,3 +1078,93 @@ export const getTutoringType = async (
     message: "Successfully fetched this tutoring type!",
   };
 };
+
+export const getTutorHours = async (
+  queryData: UniqueTutorQuery
+): Promise<SupabaseResponse<number>> => {
+  const tutorIdResponse = await getTutorId(queryData);
+
+  if (tutorIdResponse.error) {
+    return tutorIdResponse;
+  }
+
+  const tutor_id = tutorIdResponse.data;
+  const hourResponses = await supabase.rpc("hour", { tutor_id })
+
+  if (hourResponses.error) {
+    console.log(hourResponses.error);
+    return {
+      error: true,
+      message: "There was an error fetching CougarCoin balance!",
+    };
+  }
+
+  const balance = hourResponses.data || 0;
+
+  return {
+    data: balance,
+    error: false,
+    message: "Successfully fetched balance!",
+  };
+};
+
+
+export const getTutorLeaderboard = async (
+  maxSlots: number
+): Promise<SupabaseResponse<string[]>> => {
+  const transactionsResponse = await supabase
+    .from("tutor_logs")
+    .select("tutor_id");
+
+  if (transactionsResponse.error) {
+    return {
+      error: true,
+      message: "There was an error fetching transactions!",
+    };
+  }
+
+  const tutorUniqueBalancePairs: { tutor_id: string; tutorBalance: number }[] = [];
+
+  for (let i = 0; i < transactionsResponse.data.length; i++) {
+    const { tutor_id } = transactionsResponse.data[i];
+    if (tutorUniqueBalancePairs.find((uci) => uci.tutor_id === tutor_id)) {
+      continue;
+    }
+    const tutorBalanceResponse = await getTutorHours({ tutor_id });
+
+    if (tutorBalanceResponse.error) {
+      return tutorBalanceResponse;
+    }
+
+    const tutorBalance = tutorBalanceResponse.data;
+    tutorUniqueBalancePairs.push({ tutor_id, tutorBalance });
+  }
+
+  tutorUniqueBalancePairs.sort((a, b) => b.tutorBalance - a.tutorBalance);
+  const arrayString: string[] = [];
+
+  for (let i = 0; i < tutorUniqueBalancePairs.length && i < maxSlots; i++) {
+    const { tutor_id, tutorBalance } = tutorUniqueBalancePairs[i];
+    const tutorIdentifierResponse = await getTutor({ tutor_id });
+    
+    if (tutorIdentifierResponse.error) {
+      continue;
+    }
+    const UUID = tutorIdentifierResponse.data.contact_id;
+    const identifierResponse = await getContact({ contact_id: UUID })
+
+    const { discord_snowflake, first_name, last_name } = identifierResponse.data;
+    const identifier = discord_snowflake
+      ? `<@${discord_snowflake}>`
+      : `${first_name} ${last_name}`;
+    const slot = `${i + 1}. ${identifier}: **${tutorBalance}**`;
+
+    arrayString.push(slot);
+  }
+
+  return {
+    data: arrayString,
+    error: false,
+    message: "Successfully fetched tutor leaderboard!",
+  };
+};

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1092,7 +1092,7 @@ export const getTutorHours = async (
   const hourResponses = await supabase.rpc("hour", { tutor_id })
 
   if (hourResponses.error) {
-    console.log(hourResponses.error);
+    console.error(hourResponses.error);
     return {
       error: true,
       message: "There was an error fetching tutor hour balance!",

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1095,7 +1095,7 @@ export const getTutorHours = async (
     console.log(hourResponses.error);
     return {
       error: true,
-      message: "There was an error fetching CougarCoin balance!",
+      message: "There was an error fetching tutor hour balance!",
     };
   }
 
@@ -1104,7 +1104,7 @@ export const getTutorHours = async (
   return {
     data: balance,
     error: false,
-    message: "Successfully fetched balance!",
+    message: "Successfully fetched tutor hour balance!",
   };
 };
 
@@ -1159,7 +1159,7 @@ export const getTutorLeaderboard = async (
 
     const { discord_snowflake, first_name, last_name } = identifierResponse.data;
     const identifier = discord_snowflake
-      ? `<@${discord_snowflake}>`
+? `<@${discord_snowflake}>`
       : `${first_name} ${last_name}`;
     const slot = `${i + 1}. ${identifier}: **${tutorBalance}**`;
 
@@ -1169,7 +1169,7 @@ export const getTutorLeaderboard = async (
   }
 
   return {
-    data: arrayString,
+    data: arrayString,  
     error: false,
     message: "Successfully fetched tutor leaderboard!",
   };


### PR DESCRIPTION
### Description
---
We created tutoring command called `/tutor-leaderboard` in order for our tutors to see who has the top hours.

### Caveats
---
#### tutor-leaderboard.ts
`tutorleaderboardBody()` is a function that returns an embed back to the tutor. Users are allowed to see a range of top tutor hours from 1-20 (Default: 10). 
#### supabase.ts
`getTutorHours` is a function that returns the sum of hours a tutor has done. A new _"Remote Procedure Call"_ which stores the actual SQL query and then returns the number. `getTutorLeaderboard()` is a function that finds all of the tutor hours and stores them within a list. We fetch all of the hours from the `getTutorHours()`, we then start pushing it towards an array of dictionary(id, hours). We sort the array, and finally start creating the string for the embed. In order to get the active students, we have to check that within the logs that they are active tutors so we use the `getTutor()` function, and will continue if they're not an active tutor. After that we are then going to start putting the user in order within the embed and list them accordingly. 
### Pictures
---
Here is an example for options:
![image](https://github.com/CougarCS/CougarCS-Bot/assets/108897899/64d1de6e-88f9-492e-a999-12390472bd1a)
Then the output of the command would look like:
![image](https://github.com/CougarCS/CougarCS-Bot/assets/108897899/0a6d9a7b-8bbc-4c07-8e8a-2644229b0607)

The full command with multiple people would look like this (with default value of 10):
![image](https://github.com/CougarCS/CougarCS-Bot/assets/108897899/cbf3fc0d-7763-457c-bc86-41e374b1ef7e)
![image](https://github.com/CougarCS/CougarCS-Bot/assets/108897899/ad09cca8-a5d7-42be-bffd-539c3e442422)
