### PR TITLE
Adjusting Claim Command

### DIFF
--- a/src/commands/user-commands/claim.ts
+++ b/src/commands/user-commands/claim.ts
@@ -18,7 +18,7 @@ export const claim: Command = {
       option
         .setName("psid")
         .setDescription("Your UH issued PSID number (7 digit id)!")
-        .setRequired(false)
+        .setRequired(true)
         .setMaxValue(9999999)
         .setMinValue(1000000)
     )
@@ -28,7 +28,7 @@ export const claim: Command = {
         .setDescription(
           "The email that you used to purchase a CougarCS membership!"
         )
-        .setRequired(false)
+        .setRequired(true)
     ),
 
   run: async (interaction) => {

--- a/src/commands/user-commands/claim.ts
+++ b/src/commands/user-commands/claim.ts
@@ -76,11 +76,7 @@ export const claim: Command = {
     const discord_snowflake = user.id;
     let contactResponse: SupabaseResponse<ContactSelect>;
 
-    if (uh_id && email) {
-      contactResponse = await getContact({ uh_id, email });
-    } else {
-      contactResponse = await getContact({ discord_snowflake });
-    }
+    contactResponse = await getContact({ uh_id, email });
 
     if (contactResponse.error) {
       await sendError(


### PR DESCRIPTION
### Description
---
Readjusted the claim command, because we had issues where people were only inputting one of the options when they need both in order for the command to work properly.

### Caveats
---
#### claim.ts
When a user is required to use both, we don't need to check their discord snowflake anymore. It becomes redundant to have it within our `claim.js`. This is the portion of the code that is in question.
![image](https://github.com/CougarCS/CougarCS-Bot/assets/108897899/aa8dd01e-9fe9-412b-8e65-285a3df9b40c)
### Pictures
---
Here is the way the command will now look. 
![image](https://github.com/CougarCS/CougarCS-Bot/assets/108897899/ebc9349e-3f8a-487b-bfa3-a378b75ec279)
The command will not execute if both options are not filled out. (Highlighted in red)